### PR TITLE
feature: delete by id endpoint is added

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,12 @@ stages:
               -Dsonar.organization=$(SONAR_ORGANIZATION) \
               -Dsonar.projectKey=$(SONAR_PROJECT_KEY) \
               -Dsonar.host.url=$(SONAR_HOST_URL) \
-              -Dsonar.login=$(SONAR_TOKEN)
+              -Dsonar.login=$(SONAR_TOKEN) \
+              -Dsonar.pullrequest.key=$(System.PullRequest.PullRequestNumber) \
+              -Dsonar.pullrequest.branch=$(System.PullRequest.SourceBranch) \
+              -Dsonar.pullrequest.base=main \
+              -Dsonar.pullrequest.provider=GitHub \
+              -Dsonar.pullrequest.github.repository=EncyclopediaGalactica/EG
 
   - stage: Main_branch
     condition: and(eq(variables['System.PullRequest.SourceBranch'], ''), eq(variables['Build.SourceBranch'],'refs/heads/main'))
@@ -56,7 +61,7 @@ stages:
         dependsOn: build_solution
         steps:
           - script: mvn clean install -f pom.xml
-            
+
       - job: sonar_analyze
         displayName: Sonar Analyze
         dependsOn: test_solution

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ stages:
       - job: build_solution
         displayName: Build Solution
         steps:
-          - script: mvn compile -f pom.xml
+          - script: mvn clean compile -f pom.xml
 
       - job: test_solution
         displayName: Test Solution
@@ -54,7 +54,7 @@ stages:
       - job: build_solution
         displayName: Build Solution
         steps:
-          - script: mvn compile -f pom.xml
+          - script: mvn clean compile -f pom.xml
 
       - job: test_solution
         displayName: Test Solution

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.77.Final</version>
+            <version>4.1.79.Final</version>
             <classifier>osx-aarch_64</classifier>
         </dependency>
     </dependencies>

--- a/src/main/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatController.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatController.java
@@ -3,49 +3,59 @@ package com.encyclopediagalactica.sourceformats.controllers;
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
+import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import lombok.NonNull;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.NonNull;
-import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/sourceformat")
 public class SourceFormatController {
 
   private final GetAllServiceInterface getAllService;
   private final AddServiceInterface addService;
+  private final DeleteByIdServiceInterface deleteByIdService;
 
   public SourceFormatController(
       @NonNull GetAllServiceInterface getAllService,
-      @NonNull  AddServiceInterface addService) {
+      @NonNull AddServiceInterface addService,
+      @NonNull DeleteByIdServiceInterface deleteByIdService) {
     this.getAllService = getAllService;
     this.addService = addService;
+    this.deleteByIdService = deleteByIdService;
   }
 
   @GetMapping(
-      value = "/getall")
+      value = "/sourceformats")
   @ResponseBody
   public List<SourceFormatDto> getAll() {
     return getAllService.getAll();
   }
 
   @PostMapping(
+      value = "/sourceformats",
       consumes = "application/json"
   )
   @ResponseBody
   public ResponseEntity<SourceFormatDto> add(@RequestBody SourceFormatDto dto) {
-    
+
     SourceFormatDto result = addService.add(dto);
     return new ResponseEntity<>(result, HttpStatus.CREATED);
+  }
+
+  @DeleteMapping(
+      value = "/sourceformats/{sourceFormatId}"
+  )
+  @ResponseStatus(value = HttpStatus.NO_CONTENT)
+  public void deleteById(@PathVariable long sourceFormatId) {
+    this.deleteByIdService.deleteById(sourceFormatId);
   }
 }

--- a/src/main/java/com/encyclopediagalactica/sourceformats/dto/SourceFormatDto.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/dto/SourceFormatDto.java
@@ -1,8 +1,6 @@
 package com.encyclopediagalactica.sourceformats.dto;
 
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -10,14 +8,12 @@ import javax.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.validator.constraints.Length;
-import org.springframework.boot.jackson.JsonComponent;
 
 /**
  * SourceFormatDto class.
  * <p>
- *   This DTO class is used to transfer a selected SourceFormat object properties
- *   to external services like UI.
+ * This DTO class is used to transfer a selected SourceFormat object properties
+ * to external services like UI.
  * </p>
  */
 @Getter
@@ -30,7 +26,9 @@ public class SourceFormatDto {
   @NotNull
   @NotEmpty
   @NotBlank
-  @Size(min = 3, max = 255)
+  @Size(
+      min = 3,
+      max = 255)
   private String name;
 
   //<editor-fold desc="ctor">

--- a/src/main/java/com/encyclopediagalactica/sourceformats/entities/SourceFormat.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/entities/SourceFormat.java
@@ -8,15 +8,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.validator.constraints.Length;
 //</editor-fold>
 
 /**
@@ -29,7 +26,6 @@ import org.hibernate.validator.constraints.Length;
  * <li>presentation related properties</li>
  * <li>validation rules</li>
  * </p>
- * 
  */
 @Entity
 @Table(name = "source_format")
@@ -49,10 +45,12 @@ public class SourceFormat {
    * Name of the SourceFormat
    */
   @Column(name = "name")
-  @NotNull 
-  @NotEmpty 
-  @NotBlank 
-  @Size(min = 3, max = 255)
+  @NotNull
+  @NotEmpty
+  @NotBlank
+  @Size(
+      min = 3,
+      max = 255)
   private String name;
 
   //<editor-fold desc="ctor">

--- a/src/main/java/com/encyclopediagalactica/sourceformats/errors/ErrorMessages.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/errors/ErrorMessages.java
@@ -2,6 +2,6 @@ package com.encyclopediagalactica.sourceformats.errors;
 
 public class ErrorMessages {
 
-  public static String VALIDATION_ERROR = "Validation error!";
-  
+  public static final String VALIDATION_ERROR = "Validation error!";
+
 }

--- a/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/AddService.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/AddService.java
@@ -31,45 +31,44 @@ public class AddService implements AddServiceInterface {
   @Override
   public SourceFormatDto add(
       @NonNull @Valid SourceFormatDto dto) {
-    
+
     this.trimDtoStringProperties(dto);
     this.validateInputDto(dto);
     SourceFormat sourceFormat = mapper.mapSourceFormatDtoToSourceFormat(dto);
-    
+
     this.trimEntityStringProperties(sourceFormat);
     this.validateEntity(sourceFormat);
     SourceFormat result = repository.save(sourceFormat);
-    SourceFormatDto resultDto = mapper.mapSourceFormatToSourceFormatDto(result);
-    
-    return resultDto;
+
+    return mapper.mapSourceFormatToSourceFormatDto(result);
   }
-  
+
   private void trimDtoStringProperties(SourceFormatDto dto) {
-    if(dto.getName() != null) {
+    if (dto.getName() != null) {
       dto.setName(dto.getName().trim());
     }
   }
-  
+
   private void validateInputDto(SourceFormatDto dto) {
     ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
     Validator validator = factory.getValidator();
     Set<ConstraintViolation<SourceFormatDto>> violations = validator.validate(dto);
-    if(!violations.isEmpty()){
+    if (!violations.isEmpty()) {
       throw new ConstraintViolationException(violations);
     }
   }
-  
+
   private void trimEntityStringProperties(SourceFormat sf) {
-    if(sf.getName() != null) {
+    if (sf.getName() != null) {
       sf.setName(sf.getName().trim());
     }
   }
-  
+
   private void validateEntity(SourceFormat sourceFormat) {
     ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
     Validator validator = factory.getValidator();
     Set<ConstraintViolation<SourceFormat>> violations = validator.validate(sourceFormat);
-    if(!violations.isEmpty()){
+    if (!violations.isEmpty()) {
       throw new ConstraintViolationException(violations);
     }
   }

--- a/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/DeleteByIdService.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/DeleteByIdService.java
@@ -3,20 +3,24 @@ package com.encyclopediagalactica.sourceformats.services.implementations;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
 import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
 import lombok.NonNull;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DeleteByIdService implements DeleteByIdServiceInterface {
-  
+
   private final SourceFormatRepository sourceFormatRepository;
 
-  public DeleteByIdService(
-      @NonNull SourceFormatRepository sourceFormatRepository) {
+  public DeleteByIdService(@NonNull SourceFormatRepository sourceFormatRepository) {
     this.sourceFormatRepository = sourceFormatRepository;
   }
 
   @Override
   public void deleteById(Long id) {
+
+    if (id == 0) {
+      throw new InvalidDataAccessApiUsageException("The provided entity Id cannot be 0");
+    }
     this.sourceFormatRepository.deleteById(id);
   }
 }

--- a/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/GetAllService.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/services/implementations/GetAllService.java
@@ -26,7 +26,6 @@ public class GetAllService implements GetAllServiceInterface {
   @Override
   public List<SourceFormatDto> getAll() {
     List<SourceFormat> sourceFormats = (List<SourceFormat>) repository.findAll();
-    List<SourceFormatDto> sourceFormatDtos = sourceFormatMapper.mapSourceFormatsToSourceFormatDtos(sourceFormats);
-    return sourceFormatDtos;
+    return sourceFormatMapper.mapSourceFormatsToSourceFormatDtos(sourceFormats);
   }
 }

--- a/src/main/java/com/encyclopediagalactica/sourceformats/services/interfaces/DeleteByIdServiceInterface.java
+++ b/src/main/java/com/encyclopediagalactica/sourceformats/services/interfaces/DeleteByIdServiceInterface.java
@@ -1,9 +1,13 @@
 package com.encyclopediagalactica.sourceformats.services.interfaces;
 
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+
 public interface DeleteByIdServiceInterface {
 
   /**
    * Deletes the given SourceFormat from the system.
+   *
    * @param id the unique identifier of the entity
    * @throws InvalidDataAccessApiUsageException when the input is null
    * @throws EmptyResultDataAccessException when there is no such entity

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/AddServiceE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/AddServiceE2ETests.java
@@ -2,13 +2,10 @@ package com.encyclopediagalactica.sourceformats.E2E;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.errors.ErrorMessages;
 import com.encyclopediagalactica.sourceformats.testdata.TestDataProviders;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -16,29 +13,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import reactor.core.publisher.Mono;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class AddServiceE2ETests extends TestDataProviders {
-  
+
   @Autowired
   private WebTestClient webTestClient;
-  
+
   @ParameterizedTest
   @MethodSource("sourceFormat_new_entity_dto_inputValidationProvider")
   public void shouldReturn_400_whenInputIsInvalid(String name) throws JsonProcessingException {
-    
+
     // Arrange
     SourceFormatDto dto = SourceFormatDto.builder().name(name).build();
-    
+
     // Act && Assert
     this.webTestClient
         .post()
-        .uri("/sourceformat")
+        .uri("/sourceformats")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto)
         .exchange()
@@ -46,33 +41,33 @@ public class AddServiceE2ETests extends TestDataProviders {
         .isBadRequest()
         .expectBody(String.class).isEqualTo(ErrorMessages.VALIDATION_ERROR);
   }
-  
+
   @Test
-  public void shouldReturn_415_whenMediaTypeIsIncorrect(){
-    
+  public void shouldReturn_415_whenMediaTypeIsIncorrect() {
+
     // Act && Assert
     this.webTestClient
         .post()
-        .uri("/sourceformat")
+        .uri("/sourceformats")
         .contentType(MediaType.APPLICATION_XML)
         .bodyValue(
             "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
-            "<advice xmlns=\"http://www.springframework.org/schema/cache\"></advice>")
+                "<advice xmlns=\"http://www.springframework.org/schema/cache\"></advice>")
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
   }
-  
+
   @Test
   public void shouldReturn_201_whenANewEntityIsCreated() {
-    
+
     // Arrange
     SourceFormatDto dto = SourceFormatDto.builder().name("name").build();
-    
+
     // Act && Assert
     SourceFormatDto result = this.webTestClient
         .post()
-        .uri("/sourceformat")
+        .uri("/sourceformats")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto)
         .exchange()

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/AddServiceE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/AddServiceE2ETests.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.errors.ErrorMessages;
 import com.encyclopediagalactica.sourceformats.testdata.TestDataProviders;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,7 +24,7 @@ public class AddServiceE2ETests extends TestDataProviders {
 
   @ParameterizedTest
   @MethodSource("sourceFormat_new_entity_dto_inputValidationProvider")
-  public void shouldReturn_400_whenInputIsInvalid(String name) throws JsonProcessingException {
+  public void shouldReturn_400_whenInputIsInvalid(String name) {
 
     // Arrange
     SourceFormatDto dto = SourceFormatDto.builder().name(name).build();
@@ -77,6 +76,7 @@ public class AddServiceE2ETests extends TestDataProviders {
         .returnResult()
         .getResponseBody();
 
+    assertThat(result).isNotNull();
     assertThat(result.getName()).isNotNull();
     assertThat(result.getName()).isEqualTo(dto.getName());
     assertThat(result.getId()).isGreaterThan(0);

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/DeleteByIdEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/DeleteByIdEndpointE2ETests.java
@@ -57,6 +57,7 @@ public class DeleteByIdEndpointE2ETests {
         .returnResult().getResponseBody();
 
     // Act
+    assertThat(dto1Result).isNotNull();
     this.webTestClient
         .delete()
         .uri("/sourceformats/" + dto1Result.getId())
@@ -74,6 +75,7 @@ public class DeleteByIdEndpointE2ETests {
     assertThat(result).isNotNull();
     assertThat(result).isNotEmpty();
     assertThat(result.size()).isEqualTo(1);
+    assertThat(dto2Result).isNotNull();
     SourceFormatDto res = result.stream().filter(f -> f.getName().equals(dto2Result.getName()))
         .findFirst()
         .orElse(null);

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/DeleteByIdEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/DeleteByIdEndpointE2ETests.java
@@ -1,0 +1,86 @@
+package com.encyclopediagalactica.sourceformats.E2E;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class DeleteByIdEndpointE2ETests {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Test
+  void shouldReturn_400_whenZeroValueSentToTheEndpoint() {
+    // Act && Assert
+    this.webTestClient
+        .delete()
+        .uri("/sourceformats/0")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldReturn_204_whenTheEntityIsDeletedSuccessfully() {
+    // Arrange
+    SourceFormatDto dto1 = SourceFormatDto.builder().name("name").build();
+    SourceFormatDto dto2 = SourceFormatDto.builder().name("name2").build();
+    SourceFormatDto dto1Result = this.webTestClient
+        .post()
+        .uri("/sourceformats")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(dto1)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody(SourceFormatDto.class)
+        .returnResult()
+        .getResponseBody();
+    SourceFormatDto dto2Result = this.webTestClient
+        .post()
+        .uri("/sourceformats")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(dto2)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody(SourceFormatDto.class)
+        .returnResult().getResponseBody();
+
+    // Act
+    this.webTestClient
+        .delete()
+        .uri("/sourceformats/" + dto1Result.getId())
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // Assert
+    List<SourceFormatDto> result = this.webTestClient
+        .get()
+        .uri("/sourceformats")
+        .exchange()
+        .expectBodyList(SourceFormatDto.class)
+        .returnResult().getResponseBody();
+    assertThat(result).isNotNull();
+    assertThat(result).isNotEmpty();
+    assertThat(result.size()).isEqualTo(1);
+    SourceFormatDto res = result.stream().filter(f -> f.getName().equals(dto2Result.getName()))
+        .findFirst()
+        .orElse(null);
+    assertThat(res).isNotNull();
+    assertThat(res.getId()).isGreaterThan(0);
+    assertThat(res.getName()).isEqualTo(dto2Result.getName());
+
+  }
+
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/GetAllServiceE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/GetAllServiceE2ETests.java
@@ -2,10 +2,8 @@ package com.encyclopediagalactica.sourceformats.E2E;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collection;
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
-import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,29 +17,29 @@ public class GetAllServiceE2ETests {
 
   @Autowired
   private WebTestClient webTestClient;
-  
+
   @Test
   public void shouldReturn_200_and_listOfDtos_whenThereIsDataInTheDatabase() {
-    
+
     // Arrange
     SourceFormatDto dto1 = SourceFormatDto.builder().name("name1").build();
     SourceFormatDto dto2 = SourceFormatDto.builder().name("name2").build();
-    
-    this.webTestClient.post().uri("/sourceformat")
+
+    this.webTestClient.post().uri("/sourceformats")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto1)
         .exchange()
         .expectStatus()
         .isCreated();
-    this.webTestClient.post().uri("/sourceformat")
+    this.webTestClient.post().uri("/sourceformats")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto2)
         .exchange()
         .expectStatus()
         .isCreated();
-    
+
     // Act && Assert
-    List<SourceFormatDto> result = this.webTestClient.get().uri("/sourceformat/getall")
+    List<SourceFormatDto> result = this.webTestClient.get().uri("/sourceformats")
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -53,11 +51,11 @@ public class GetAllServiceE2ETests {
     assertThat(result).isNotNull();
     assertThat(result.size()).isEqualTo(2);
   }
-  
+
   @Test
   public void shouldReturn_200_and_emptyList_whenThereAreNoEntitiesInTheDatabase() {
     // Act && Assert
-    List<SourceFormatDto> result = this.webTestClient.get().uri("/sourceformat/getall")
+    List<SourceFormatDto> result = this.webTestClient.get().uri("/sourceformats")
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()

--- a/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
@@ -1,0 +1,64 @@
+package com.encyclopediagalactica.sourceformats.controllers;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
+import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
+import com.encyclopediagalactica.sourceformats.services.implementations.AddService;
+import com.encyclopediagalactica.sourceformats.services.implementations.DeleteByIdService;
+import com.encyclopediagalactica.sourceformats.services.implementations.GetAllService;
+import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
+import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
+import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SourceFormatControllerTests {
+
+  @Autowired
+  private SourceFormatRepository sourceFormatRepository;
+
+  @Autowired
+  private SourceFormatMapper mapper;
+
+  @Test
+  void shouldThrow_whenGetAllService_ctorInjectIsNull() {
+    // Arrange
+    AddServiceInterface addService = new AddService(sourceFormatRepository, mapper);
+    DeleteByIdServiceInterface deleteByIdService = new DeleteByIdService(sourceFormatRepository);
+    GetAllServiceInterface getAllService = null;
+
+    // Act && Assert
+    assertThatThrownBy(() -> {
+      new SourceFormatController(getAllService, addService, deleteByIdService);
+    }).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldThrow_whenAddService_ctorInjectIsNull() {
+    // Arrange
+    AddServiceInterface addService = null;
+    DeleteByIdServiceInterface deleteByIdService = new DeleteByIdService(sourceFormatRepository);
+    GetAllServiceInterface getAllService = new GetAllService(sourceFormatRepository, mapper);
+
+    // Act && Assert
+    assertThatThrownBy(() -> {
+      new SourceFormatController(getAllService, addService, deleteByIdService);
+    }).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldThrow_whenDeleteByIdService_ctorInjectIsNull() {
+    // Arrange
+    AddServiceInterface addService = new AddService(sourceFormatRepository, mapper);
+    DeleteByIdServiceInterface deleteByIdService = null;
+    GetAllServiceInterface getAllService = new GetAllService(sourceFormatRepository, mapper);
+
+    // Act && Assert
+    assertThatThrownBy(() -> {
+      new SourceFormatController(getAllService, addService, deleteByIdService);
+    }).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
@@ -31,9 +31,7 @@ public class SourceFormatControllerTests {
     GetAllServiceInterface getAllService = null;
 
     // Act && Assert
-    assertThatThrownBy(() -> {
-      new SourceFormatController(getAllService, addService, deleteByIdService);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new SourceFormatController(getAllService, addService, deleteByIdService)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -44,9 +42,7 @@ public class SourceFormatControllerTests {
     GetAllServiceInterface getAllService = new GetAllService(sourceFormatRepository, mapper);
 
     // Act && Assert
-    assertThatThrownBy(() -> {
-      new SourceFormatController(getAllService, addService, deleteByIdService);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new SourceFormatController(getAllService, addService, deleteByIdService)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -57,8 +53,6 @@ public class SourceFormatControllerTests {
     GetAllServiceInterface getAllService = new GetAllService(sourceFormatRepository, mapper);
 
     // Act && Assert
-    assertThatThrownBy(() -> {
-      new SourceFormatController(getAllService, addService, deleteByIdService);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new SourceFormatController(getAllService, addService, deleteByIdService)).isInstanceOf(NullPointerException.class);
   }
 }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_DtoListToEntityList_Tests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_DtoListToEntityList_Tests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+@SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SourceFormatMappers_DtoListToEntityList_Tests {
 
@@ -26,9 +27,7 @@ public class SourceFormatMappers_DtoListToEntityList_Tests {
   @Test
   public void shouldThrowWhen_InputIsNull() {
     // Act & Assert
-    assertThatThrownBy(() -> {
-      sut.mapSourceFormatDtosToSourceFormats(null);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> sut.mapSourceFormatDtosToSourceFormats(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -49,15 +48,17 @@ public class SourceFormatMappers_DtoListToEntityList_Tests {
     List<SourceFormat> result = sut.mapSourceFormatDtosToSourceFormats(sourceFormatDtos);
 
     // Result
-    assertThat(result.stream().count()).isEqualTo(2);
+    assertThat((long) result.size()).isEqualTo(2);
     SourceFormat first = result.stream().filter(f -> f.getId() == firstId)
         .findAny()
         .orElse(null);
+    assertThat(first).isNotNull();
     assertThat(first.getId()).isEqualTo(firstId);
     assertThat(first.getName()).isEqualTo(firstName);
     SourceFormat second = result.stream().filter(f -> f.getId() == secondId)
         .findAny()
         .orElse(null);
+    assertThat(second).isNotNull();
     assertThat(second.getId()).isEqualTo(secondId);
     assertThat(second.getName()).isEqualTo(secondName);
   }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_EntityListToDtoList_Tests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_EntityListToDtoList_Tests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+@SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SourceFormatMappers_EntityListToDtoList_Tests {
 
@@ -26,9 +27,7 @@ public class SourceFormatMappers_EntityListToDtoList_Tests {
   @Test
   public void shouldThrowWhen_InputIsNull() {
     // Act & Assert
-    assertThatThrownBy(() -> {
-      sut.mapSourceFormatsToSourceFormatDtos(null);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> sut.mapSourceFormatsToSourceFormatDtos(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -49,15 +48,17 @@ public class SourceFormatMappers_EntityListToDtoList_Tests {
     List<SourceFormatDto> result = sut.mapSourceFormatsToSourceFormatDtos(sourceFormats);
 
     // Result
-    assertThat(result.stream().count()).isEqualTo(2);
+    assertThat((long) result.size()).isEqualTo(2);
     SourceFormatDto first = result.stream().filter(f -> f.getId() == firstId)
         .findAny()
         .orElse(null);
+    assertThat(first).isNotNull();
     assertThat(first.getId()).isEqualTo(firstId);
     assertThat(first.getName()).isEqualTo(firstName);
     SourceFormatDto second = result.stream().filter(f -> f.getId() == secondId)
         .findAny()
         .orElse(null);
+    assertThat(second).isNotNull();
     assertThat(second.getId()).isEqualTo(secondId);
     assertThat(second.getName()).isEqualTo(secondName);
   }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_SingleDtoToEntity_Tests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_SingleDtoToEntity_Tests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+@SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SourceFormatMappers_SingleDtoToEntity_Tests {
 
@@ -24,9 +25,7 @@ public class SourceFormatMappers_SingleDtoToEntity_Tests {
   @Test
   public void shouldThrowWhen_InputIsNull() {
     // Act & Assert
-    assertThatThrownBy(() -> {
-      sut.mapSourceFormatDtoToSourceFormat(null);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> sut.mapSourceFormatDtoToSourceFormat(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_SingleEntityToDto_Tests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SourceFormatMappers_SingleEntityToDto_Tests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+@SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SourceFormatMappers_SingleEntityToDto_Tests {
 
@@ -24,9 +25,7 @@ public class SourceFormatMappers_SingleEntityToDto_Tests {
   @Test
   public void shouldThrowWhen_InputIsNull() {
     // Act & Assert
-    assertThatThrownBy(() -> {
-      sut.mapSourceFormatToSourceFormatDto(null);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> sut.mapSourceFormatToSourceFormatDto(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/DeleteByIdTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/DeleteByIdTests.java
@@ -24,34 +24,34 @@ import org.springframework.test.context.TestPropertySource;
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class DeleteByIdTests {
-  
+
   @Autowired
   private SourceFormatRepository repository;
-  
+
   @Test
   public void shouldDelete() {
-    
+
     // Arrange
     SourceFormat sf = new SourceFormat("asd");
     SourceFormat sfResult = repository.save(sf);
-    
+
     // Act
     repository.deleteById(sfResult.getId());
-    
+
     // Assert
     List<SourceFormat> getAll = (List<SourceFormat>) repository.findAll();
     assertThat(getAll.size()).isEqualTo(0);
   }
-  
+
   @Test
   public void shouldThrow_whenThereIsNoEntityToBeDeleted() {
     // Act && Assert
-    assertThatThrownBy(() -> {repository.deleteById(100L);}).isInstanceOf(EmptyResultDataAccessException.class);
+    assertThatThrownBy(() -> repository.deleteById(100L)).isInstanceOf(EmptyResultDataAccessException.class);
   }
-  
+
   @Test
   public void shouldThrow_whenInputIsInvalid() {
     // Act && Assert
-    assertThatThrownBy(() -> {repository.deleteById(null);}).isInstanceOf(InvalidDataAccessApiUsageException.class);
+    assertThatThrownBy(() -> repository.deleteById(null)).isInstanceOf(InvalidDataAccessApiUsageException.class);
   }
 }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/SaveTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/SaveTests.java
@@ -39,11 +39,11 @@ public class SaveTests {
     assertThat(result.getId()).isGreaterThan(0);
     assertThat(result.getName()).isEqualTo(sourceFormat.getName());
   }
-  
+
   @Test
   public void shouldThrow_whenNullInputIsProvided() {
-    
+
     // Act
-    assertThatThrownBy(() -> {sourceFormatRepository.save(null);}).isInstanceOf(InvalidDataAccessApiUsageException.class);
+    assertThatThrownBy(() -> sourceFormatRepository.save(null)).isInstanceOf(InvalidDataAccessApiUsageException.class);
   }
 }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceInputValidationTests.java
@@ -3,14 +3,11 @@ package com.encyclopediagalactica.sourceformats.services.sourceformat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.validation.ConstraintViolationException;
-import java.util.stream.Stream;
 import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
 import com.encyclopediagalactica.sourceformats.testdata.TestDataProviders;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,10 +31,7 @@ public class AddServiceInputValidationTests extends TestDataProviders {
   @MethodSource("sourceFormat_new_entity_dto_inputValidationProvider")
   public void shouldThrow_whenInputIsInvalid(String name) {
     // Act && Assert
-    assertThatThrownBy(() -> {
-      addService.add(
-          SourceFormatDto.builder().name(name).build()
-      );
-    }).isInstanceOf(ConstraintViolationException.class);
+    assertThatThrownBy(() -> addService.add(SourceFormatDto.builder().name(name).build()))
+        .isInstanceOf(ConstraintViolationException.class);
   }
 }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
@@ -28,9 +28,7 @@ public class DeleteByIdServiceInputValidationTests {
   void shouldThrow_whenInputIsInvalid() {
 
     // Act && Assert
-    assertThatThrownBy(() -> {
-      this.deleteByIdService.deleteById(0L);
-    }).isInstanceOf(InvalidDataAccessApiUsageException.class);
+    assertThatThrownBy(() -> this.deleteByIdService.deleteById(0L)).isInstanceOf(InvalidDataAccessApiUsageException.class);
   }
 
 }

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
@@ -1,0 +1,36 @@
+package com.encyclopediagalactica.sourceformats.services.sourceformat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
+import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ContextConfiguration(classes = SourceFormatServiceApplication.class)
+@TestPropertySource(
+    properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class DeleteByIdServiceInputValidationTests {
+
+  @Autowired
+  private DeleteByIdServiceInterface deleteByIdService;
+
+  @Test
+  void shouldThrow_whenInputIsInvalid() {
+
+    // Act && Assert
+    assertThatThrownBy(() -> {
+      this.deleteByIdService.deleteById(0L);
+    }).isInstanceOf(InvalidDataAccessApiUsageException.class);
+  }
+
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
@@ -1,0 +1,83 @@
+package com.encyclopediagalactica.sourceformats.services.sourceformat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
+import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
+import com.encyclopediagalactica.sourceformats.services.implementations.DeleteByIdService;
+import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
+import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
+import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ContextConfiguration(classes = SourceFormatServiceApplication.class)
+@TestPropertySource(
+    properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class DeleteByIdServiceTests {
+
+  @Autowired
+  private AddServiceInterface addService;
+
+  @Autowired
+  private DeleteByIdServiceInterface deleteByIdService;
+
+  @Autowired
+  private GetAllServiceInterface getAllService;
+
+  @Test
+  void shouldThrow_whenCtorInjectIsNull() {
+
+    // Act && Assert
+    assertThatThrownBy(() -> {
+      new DeleteByIdService(null);
+    }).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldDelete_theDesignatedEntity_andNoReturnValue() {
+
+    // Arrange
+    SourceFormatDto dto1 = SourceFormatDto.builder().name("name1").build();
+    SourceFormatDto dto2 = SourceFormatDto.builder().name("name2").build();
+    SourceFormatDto dto1Result = this.addService.add(dto1);
+    SourceFormatDto dto2Result = this.addService.add(dto2);
+
+    // Act
+    this.deleteByIdService.deleteById(dto1Result.getId());
+
+    // Assert
+    List<SourceFormatDto> list = this.getAllService.getAll();
+    assertThat(list).isNotNull();
+    assertThat(list).isNotEmpty();
+    assertThat(list.size()).isEqualTo(1);
+    SourceFormatDto dto = list.stream().filter(f -> f.getName().equals(dto2.getName()))
+        .findFirst()
+        .orElse(null);
+    assertThat(dto).isNotNull();
+    assertThat(dto.getName()).isEqualTo(dto2.getName());
+    assertThat(dto.getId()).isGreaterThan(0);
+  }
+
+  @Test
+  void shouldThrow_whenNoSuchEntity() {
+
+    // Act & Assert
+    assertThatThrownBy(() -> {
+      this.deleteByIdService.deleteById(100L);
+    }).isInstanceOf(EmptyResultDataAccessException.class);
+
+  }
+
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
@@ -18,6 +18,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
+@SuppressWarnings("unused")
 @SpringBootTest
 @ContextConfiguration(classes = SourceFormatServiceApplication.class)
 @TestPropertySource(
@@ -40,9 +41,7 @@ class DeleteByIdServiceTests {
   void shouldThrow_whenCtorInjectIsNull() {
 
     // Act && Assert
-    assertThatThrownBy(() -> {
-      new DeleteByIdService(null);
-    }).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new DeleteByIdService(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -74,9 +73,7 @@ class DeleteByIdServiceTests {
   void shouldThrow_whenNoSuchEntity() {
 
     // Act & Assert
-    assertThatThrownBy(() -> {
-      this.deleteByIdService.deleteById(100L);
-    }).isInstanceOf(EmptyResultDataAccessException.class);
+    assertThatThrownBy(() -> this.deleteByIdService.deleteById(100L)).isInstanceOf(EmptyResultDataAccessException.class);
 
   }
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/GetAllTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/GetAllTests.java
@@ -14,6 +14,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
+@SuppressWarnings("unused")
 @SpringBootTest
 @ContextConfiguration(classes = SourceFormatServiceApplication.class)
 @TestPropertySource(
@@ -22,25 +23,25 @@ import org.springframework.test.context.TestPropertySource;
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class GetAllTests {
-  
+
   @Autowired
   private GetAllServiceInterface getAllService;
-  
+
   @Autowired
   private AddServiceInterface addService;
-  
+
   @Test
   public void shouldReturn_ListOfObjects() {
-    
+
     // Arrange
     SourceFormatDto dto1 = SourceFormatDto.builder().name("asd").build();
     SourceFormatDto dto2 = SourceFormatDto.builder().name("asdd").build();
     SourceFormatDto dtoResult1 = this.addService.add(dto1);
     SourceFormatDto dtoResult2 = this.addService.add(dto2);
-    
+
     // Act
     List<SourceFormatDto> result = this.getAllService.getAll();
-    
+
     // Assert
     assertThat((long) result.size()).isEqualTo(2);
     SourceFormatDto result1 = result.stream()
@@ -50,7 +51,7 @@ public class GetAllTests {
     assertThat(result1).isNotNull();
     assertThat(result1.getId()).isGreaterThan(0);
     assertThat(result1.getName()).isEqualTo(dto1.getName());
-    
+
     SourceFormatDto result2 = result.stream()
         .filter(f -> f.getName().equals(dto2.getName()))
         .findFirst()
@@ -59,13 +60,12 @@ public class GetAllTests {
     assertThat(result2.getId()).isGreaterThan(0);
     assertThat(result2.getName()).isEqualTo(dto2.getName());
   }
-  
+
   @Test
-  public void shouldReturn_emptyList_whenNoEntitiesInTheDb()
-  {
+  public void shouldReturn_emptyList_whenNoEntitiesInTheDb() {
     // Act
     List<SourceFormatDto> result = this.getAllService.getAll();
-    
+
     // Assert
     assertThat(result).isNotNull();
     assertThat(result.size()).isEqualTo(0);


### PR DESCRIPTION
By this PR the SourceFormat endpoint is capable of deleting
SourceFormat entities.
The endpoint is available DELETE url://sourceformats/{sourceFormatId}

This implementation also includes all the testing
with high coverage.