### PR TITLE
chore: adding tags to tests

### DIFF
--- a/.run/Everything.run.xml
+++ b/.run/Everything.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Everything" type="JUnit" factoryName="JUnit">
+    <module name="eg-sourceformat" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="package" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="wholeProject" />
+    </option>
+    <fork_mode value="class" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Integration.run.xml
+++ b/.run/Integration.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration" type="JUnit" factoryName="JUnit">
+    <module name="eg-sourceformat" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="tags" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="wholeProject" />
+    </option>
+    <tag value="integration" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Unit.run.xml
+++ b/.run/Unit.run.xml
@@ -1,13 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Whole project" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
+  <configuration default="false" name="Unit" type="JUnit" factoryName="JUnit">
     <module name="eg-sourceformat" />
     <option name="PACKAGE_NAME" value="" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="package" />
+    <option name="TEST_OBJECT" value="tags" />
     <option name="TEST_SEARCH_SCOPE">
       <value defaultName="wholeProject" />
     </option>
+    <tag value="unit" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/unit & integration.run.xml
+++ b/.run/unit & integration.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="unit &amp; integration" type="JUnit" factoryName="JUnit">
+    <module name="eg-sourceformat" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="tags" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="wholeProject" />
+    </option>
+    <tag value="integration | unit" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <java.version>17</java.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     </properties>
 
     <dependencies>
@@ -63,6 +64,36 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite-commons</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
@@ -91,6 +122,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <parallel>class</parallel>
+                    <forkCount>8</forkCount>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/E2ESuite.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/E2ESuite.java
@@ -1,0 +1,22 @@
+package com.encyclopediagalactica.sourceformats.E2E;
+
+import com.encyclopediagalactica.sourceformats.E2E.sourceformats.AddEndpointE2ETests;
+import com.encyclopediagalactica.sourceformats.E2E.sourceformats.DeleteByIdEndpointE2ETests;
+import com.encyclopediagalactica.sourceformats.E2E.sourceformats.FindByIdEndpointE2ETests;
+import com.encyclopediagalactica.sourceformats.E2E.sourceformats.GetAllEndpointE2ETests;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("End-to-End Test Suite")
+@SelectClasses(
+    {
+        // SourceFormat
+        AddEndpointE2ETests.class,
+        DeleteByIdEndpointE2ETests.class,
+        FindByIdEndpointE2ETests.class,
+        GetAllEndpointE2ETests.class
+    })
+public class E2ESuite {
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/AddEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/AddEndpointE2ETests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.errors.ErrorMessages;
 import com.encyclopediagalactica.sourceformats.testdata.sourceformats.CreateNewEntityValidationDataProviders;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,7 +18,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class AddEndpointE2ETests extends CreateNewEntityValidationDataProviders {
+@Tag("e2e")
+public class AddEndpointE2ETests extends CreateNewEntityValidationDataProviders {
 
   @Autowired
   private WebTestClient webTestClient;

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/DeleteByIdEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/DeleteByIdEndpointE2ETests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +14,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class DeleteByIdEndpointE2ETests {
+@Tag("e2e")
+public class DeleteByIdEndpointE2ETests {
 
   @Autowired
   private WebTestClient webTestClient;

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/E2ESourceFormatTestSuite.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/E2ESourceFormatTestSuite.java
@@ -1,0 +1,17 @@
+package com.encyclopediagalactica.sourceformats.E2E.sourceformats;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("SourceFormat Endpoint E2E")
+@SelectClasses(
+    {
+        AddEndpointE2ETests.class,
+        DeleteByIdEndpointE2ETests.class,
+        FindByIdEndpointE2ETests.class,
+        GetAllEndpointE2ETests.class
+    })
+public class E2ESourceFormatTestSuite {
+}

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/FindByIdEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/FindByIdEndpointE2ETests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -16,7 +17,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class FindByIdEndpointE2ETests {
+@Tag("e2e")
+public class FindByIdEndpointE2ETests {
 
   @Autowired
   private WebTestClient webTestClient;

--- a/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/GetAllEndpointE2ETests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/E2E/sourceformats/GetAllEndpointE2ETests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +14,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class GetAllEndpointE2ETests {
+@Tag("e2e")
+public class GetAllEndpointE2ETests {
 
   @Autowired
   private WebTestClient webTestClient;

--- a/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/controllers/SourceFormatControllerTests.java
@@ -12,11 +12,13 @@ import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInt
 import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.FindByIdServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SuppressWarnings({"ConstantConditions", "SpringJavaInjectionPointsAutowiringInspection"})
+@Tag("integration")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SourceFormatControllerTests {
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/dto/SourceFormatDtoTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/dto/SourceFormatDtoTests.java
@@ -2,8 +2,10 @@ package com.encyclopediagalactica.sourceformats.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("unit")
 public class SourceFormatDtoTests {
 
   @Test

--- a/src/test/java/com/encyclopediagalactica/sourceformats/entities/SourceFormatEntityTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/entities/SourceFormatEntityTests.java
@@ -2,8 +2,10 @@ package com.encyclopediagalactica.sourceformats.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("unit")
 class SourceFormatEntityTests {
 
   @Test

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/DtoListToEntityListTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/DtoListToEntityListTests.java
@@ -10,12 +10,14 @@ import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
 import com.encyclopediagalactica.sourceformats.mappers.interfaces.SourceFormatMapperInterface;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceFormatMappers_DtoListToEntityList_Tests {
+@Tag("unit")
+class DtoListToEntityListTests {
 
   private SourceFormatMapperInterface sut;
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/EntityListToDtoListTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/EntityListToDtoListTests.java
@@ -10,12 +10,14 @@ import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
 import com.encyclopediagalactica.sourceformats.mappers.interfaces.SourceFormatMapperInterface;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceFormatMappers_EntityListToDtoList_Tests {
+@Tag("unit")
+class EntityListToDtoListTests {
 
   private SourceFormatMapperInterface sut;
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SingleDtoToEntityTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SingleDtoToEntityTests.java
@@ -8,12 +8,14 @@ import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
 import com.encyclopediagalactica.sourceformats.mappers.interfaces.SourceFormatMapperInterface;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceFormatMappers_SingleDtoToEntity_Tests {
+@Tag("unit")
+class SingleDtoToEntityTests {
 
   private SourceFormatMapperInterface sut;
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SingleEntityToDtoTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/mappers/sourceformat/SingleEntityToDtoTests.java
@@ -8,12 +8,14 @@ import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
 import com.encyclopediagalactica.sourceformats.mappers.interfaces.SourceFormatMapperInterface;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @SuppressWarnings("NewClassNamingConvention")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceFormatMappers_SingleEntityToDto_Tests {
+@Tag("unit")
+class SingleEntityToDtoTests {
 
   private SourceFormatMapperInterface sut;
 

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/DeleteByIdTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/DeleteByIdTests.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -24,6 +25,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class DeleteByIdTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/FindAllTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/FindAllTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -21,6 +22,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class FindAllTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/FindByIdTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/FindByIdTests.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
 import com.encyclopediagalactica.sourceformats.testdata.sourceformats.FindByIdInputValidationDataProviders;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,6 +25,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class FindByIdTests extends FindByIdInputValidationDataProviders {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/SaveTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/repositories/sourceformat/SaveTests.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.entities.SourceFormat;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -22,6 +23,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class SaveTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceInputValidationTests.java
@@ -7,6 +7,7 @@ import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
 import com.encyclopediagalactica.sourceformats.testdata.sourceformats.CreateNewEntityValidationDataProviders;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class AddServiceInputValidationTests extends CreateNewEntityValidationDataProviders {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/AddServiceTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +20,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class AddServiceTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceInputValidationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +20,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class DeleteByIdServiceInputValidationTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/DeleteByIdServiceTests.java
@@ -10,6 +10,7 @@ import com.encyclopediagalactica.sourceformats.services.implementations.DeleteBy
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.DeleteByIdServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,6 +27,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class DeleteByIdServiceTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceCtorTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceCtorTests.java
@@ -6,6 +6,7 @@ import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.mappers.implementations.SourceFormatMapper;
 import com.encyclopediagalactica.sourceformats.repositories.SourceFormatRepository;
 import com.encyclopediagalactica.sourceformats.services.implementations.FindByIdService;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +15,7 @@ import org.springframework.test.context.ContextConfiguration;
 @SuppressWarnings({"ConstantConditions", "SpringJavaInjectionPointsAutowiringInspection"})
 @SpringBootTest
 @ContextConfiguration(classes = SourceFormatServiceApplication.class)
+@Tag("integration")
 class FindByIdServiceCtorTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceInputValidationTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceInputValidationTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.services.interfaces.FindByIdServiceInterface;
 import com.encyclopediagalactica.sourceformats.testdata.sourceformats.FindByIdInputValidationDataProviders;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class FindByIdServiceInputValidationTests extends FindByIdInputValidationDataProviders {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/FindByIdServiceTests.java
@@ -8,6 +8,7 @@ import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.FindByIdServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +24,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class FindByIdServiceTests {
 
   @Autowired

--- a/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/GetAllTests.java
+++ b/src/test/java/com/encyclopediagalactica/sourceformats/services/sourceformat/GetAllTests.java
@@ -7,6 +7,7 @@ import com.encyclopediagalactica.sourceformats.SourceFormatServiceApplication;
 import com.encyclopediagalactica.sourceformats.dto.SourceFormatDto;
 import com.encyclopediagalactica.sourceformats.services.interfaces.AddServiceInterface;
 import com.encyclopediagalactica.sourceformats.services.interfaces.GetAllServiceInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,6 +23,7 @@ import org.springframework.test.context.TestPropertySource;
         "spring.jpa.hibernate.ddl-auto=create-drop"
     })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Tag("integration")
 class GetAllTests {
 
   @Autowired


### PR DESCRIPTION
By this PR tests are tagged as `unit`, `integration` or `e2e`.
The goal is being able to run only either one.